### PR TITLE
chore(Matomo): do not use cookies

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect } from "react";
 import "react-notion-x/src/styles.css";
 import "../styles/globals.css";
-import { init } from "@socialgouv/matomo-next";
+import { init, push } from "@socialgouv/matomo-next";
 
 const MATOMO_URL = process.env.NEXT_PUBLIC_MATOMO_URL;
 const MATOMO_SITE_ID = process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
@@ -13,6 +13,7 @@ const App: FC<{
   useEffect(() => {
     if (!MATOMO_URL || !MATOMO_SITE_ID) return;
     init({ url: MATOMO_URL, siteId: MATOMO_SITE_ID });
+    push(["requireCookieConsent"]);
   });
 
   return <Component {...pageProps} />;


### PR DESCRIPTION
To conform to GDPR requirements, this PR disables the use of cookies by Matomo.

Note that analytics with Matomo will still work, it's just anonymized and without the use of cookies. See [the same implementation in Berlin Open Source](https://github.com/technologiestiftung/berlin-open-source-portal/blob/3f9292eda39c65f8f98face3a73a5c65d4a7b431/src/_includes/layouts/root.liquid#L28) for which analytics in Matomo are still available.

-> [Context](https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-without-consent-or-cookie-banner/)

---

**I think that this is how it works with the `@socialgouv/matomo-next` wrapper. A second pair of eyes would be greatly appreciated, @vogelino**